### PR TITLE
Update to aas-core-meta, codegen, testgen 3191ea5, 9b47d57, 1788d59c

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: a384f52
+The revision of aas-core-codegen was: 9b47d57
 """

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         "icontract>=2.6.1,<3",
         "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@3191ea5#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a384f52#egg=aas-core-codegen"
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9b47d57#egg=aas-core-codegen"
     ],
     py_modules=["test_codegen"],
 )


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 3191ea5],
* [aas-core-codegen 9b47d57] and
* [aas-core3.0-testgen 1788d59c].

[aas-core-meta 3191ea5]: https://github.com/aas-core-works/aas-core-meta/commit/3191ea5
[aas-core-codegen 9b47d57]: https://github.com/aas-core-works/aas-core-codegen/commit/9b47d57
[aas-core3.0-testgen 1788d59c]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/1788d59c