### PR TITLE
Update to aas-core-meta, codegen, testgen 44756fb, 607f65c, bf3720d7

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: a8a510e
+The revision of aas-core-codegen was: 607f65c
 """

--- a/dev_scripts/aas_core3/types.py
+++ b/dev_scripts/aas_core3/types.py
@@ -680,10 +680,6 @@ class Qualifiable(Class):
     The value of a qualifiable element may be further qualified by one or more
     qualifiers.
 
-    .. note::
-
-        This constraint is checked at :py:class:`Submodel`.
-
     :constraint AASd-119:
         .. _constraint_AASd-119:
 
@@ -691,6 +687,10 @@ class Qualifiable(Class):
         equal to :py:attr:`QualifierKind.TEMPLATE_QUALIFIER` and the qualified element
         inherits from :py:class:`HasKind` then the qualified element shall be of
         kind Template (:py:attr:`HasKind.kind` = :py:attr:`ModellingKind.TEMPLATE`).
+
+        .. note::
+
+            This constraint is checked at :py:class:`Submodel`.
     """
 
     #: Additional qualification of a qualifiable element.
@@ -1063,28 +1063,28 @@ class AssetInformation(Class):
     does not already exist, the corresponding attribute :py:attr:`global_asset_id` is
     optional.
 
-    .. note::
-
-        :ref:`Constraint AASd-116 <constraint_AASd-116>` is important to enable a generic search across global
-        and specific asset IDs.
-
-    .. note::
-
-        In the book, :ref:`Constraint AASd-116 <constraint_AASd-116>` imposes a
-        case-insensitive equality against ``globalAssetId``. This is
-        culturally-dependent, and depends on the system settings.
-        For example, the case-folding for the letters "i" and "I" is
-        different in Turkish from English.
-
-        We implement the constraint as case-sensitive instead to allow
-        for interoperability across different culture settings.
-
     :constraint AASd-116:
         .. _constraint_AASd-116:
 
         ``globalAssetId`` is a reserved key. If used as value for
         :py:attr:`SpecificAssetID.name` then :py:attr:`SpecificAssetID.value` shall be
         identical to :py:attr:`global_asset_id`.
+
+        .. note::
+
+            :ref:`Constraint AASd-116 <constraint_AASd-116>` is important to enable a generic search across
+            global and specific asset IDs.
+
+        .. note::
+
+            In the book, :ref:`Constraint AASd-116 <constraint_AASd-116>` imposes a
+            case-insensitive equality against ``globalAssetId``. This is
+            culturally-dependent, and depends on the system settings.
+            For example, the case-folding for the letters "i" and "I" is
+            different in Turkish from English.
+
+            We implement the constraint as case-sensitive instead to allow
+            for interoperability across different culture settings.
 
     :constraint AASd-131:
         .. _constraint_AASd-131:
@@ -4585,25 +4585,60 @@ class ConceptDescription(Identifiable, HasDataSpecification):
     The description of the concept should follow a standardized schema (realized as
     data specification template).
 
-    .. note::
+    :constraint AASc-3a-004:
+        .. _constraint_AASc-3a-004:
 
-        Note: categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``PROPERTY`` or
+        ``VALUE`` using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` is mandatory and shall be
+        one of: ``DATE``, ``STRING``, ``STRING_TRANSLATABLE``, ``INTEGER_MEASURE``,
+        ``INTEGER_COUNT``, ``INTEGER_CURRENCY``, ``REAL_MEASURE``, ``REAL_COUNT``,
+        ``REAL_CURRENCY``, ``BOOLEAN``, ``RATIONAL``, ``RATIONAL_MEASURE``,
+        ``TIME``, ``TIMESTAMP``.
 
-    .. note::
+        .. note::
 
-        Note: categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+            Note: categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
 
-    .. note::
+    :constraint AASc-3a-005:
+        .. _constraint_AASc-3a-005:
 
-        Categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``REFERENCE``
+        using data specification template IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` shall be
+        one of: ``STRING``, ``IRI``, ``IRDI``.
 
-    .. note::
+        .. note::
 
-        Categories are deprecated since V3.0 of Part 1a of the document series
-        "Details of the Asset Administration Shell".
+            Note: categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
+
+    :constraint AASc-3a-006:
+        .. _constraint_AASc-3a-006:
+
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``DOCUMENT``
+        using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` shall be one of ``FILE``,
+        ``BLOB``, ``HTML``
+
+        .. note::
+
+            Categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
+
+    :constraint AASc-3a-007:
+        .. _constraint_AASc-3a-007:
+
+        For a :py:class:`ConceptDescription` with :py:attr:`category` ``QUALIFIER_TYPE``
+        using data specification IEC61360,
+        the :py:attr:`DataSpecificationIEC61360.data_type` is mandatory and shall be
+        defined.
+
+        .. note::
+
+            Categories are deprecated since V3.0 of Part 1a of the document series
+            "Details of the Asset Administration Shell".
 
     :constraint AASc-3a-008:
         .. _constraint_AASc-3a-008:
@@ -6189,20 +6224,6 @@ class DataSpecificationIEC61360(DataSpecificationContent):
 
     .. note::
 
-        It is also possible that both :py:attr:`value` and :py:attr:`value_list` are empty.
-        This is the case for concept descriptions that define the semantics of a
-        property but do not have an enumeration (:py:attr:`value_list`) as data type.
-
-    .. note::
-
-        Although it is possible to define a :py:class:`ConceptDescription` for a
-        :attr:´value_list`,
-        it is not possible to reuse this :py:attr:`value_list`.
-        It is only possible to directly add a :py:attr:`value_list` as data type
-        to a specific semantic definition of a property.
-
-    .. note::
-
         IEC61360 requires also a globally unique identifier for a concept
         description. This ID is not part of the data specification template.
         Instead the :py:attr:`ConceptDescription.id` as inherited via
@@ -6217,6 +6238,27 @@ class DataSpecificationIEC61360(DataSpecificationContent):
         :py:attr:`ConceptDescription.display_name` and
         :py:attr:`preferred_name`. Same holds for
         :py:attr:`ConceptDescription.description` and :py:attr:`definition`.
+
+    :constraint AASc-3a-010:
+        .. _constraint_AASc-3a-010:
+
+        If :py:attr:`value` is not empty then :py:attr:`value_list` shall be empty
+        and vice versa.
+
+        .. note::
+
+            It is also possible that both :py:attr:`value` and :py:attr:`value_list` are
+            empty. This is the case for concept descriptions that define the semantics
+            of a property but do not have an enumeration (:py:attr:`value_list`) as
+            data type.
+
+        .. note::
+
+            Although it is possible to define a :py:class:`ConceptDescription` for a
+            :attr:´value_list`,
+            it is not possible to reuse this :py:attr:`value_list`.
+            It is only possible to directly add a :py:attr:`value_list` as data type
+            to a specific semantic definition of a property.
 
     :constraint AASc-3a-009:
         .. _constraint_AASc-3a-009:

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -2439,7 +2439,8 @@ class _Transformer(
                         specific_asset_id.name != 'globalAssetId'
                         or (
                             (
-                                specific_asset_id.name == 'globalAssetId'
+                                (that.global_asset_id is not None)
+                                and specific_asset_id.name == 'globalAssetId'
                                 and specific_asset_id.value == that.global_asset_id
                             )
                         )
@@ -2784,7 +2785,7 @@ class _Transformer(
         if not (
             not (that.submodel_elements is not None)
             or (
-                not (that.kind != aas_types.ModellingKind.TEMPLATE)
+                not (that.kind_or_default() != aas_types.ModellingKind.TEMPLATE)
                 or (
                     all(
                         not (submodel_element.qualifiers is not None)
@@ -8085,7 +8086,7 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.data_type is None)
+                    (that.data_type is not None)
                     and (that.data_type in aas_constants.IEC_61360_DATA_TYPES_WITH_UNIT)
                 )
             )

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -30,8 +30,8 @@ setup(
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
         "icontract>=2.6.1,<3",
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@0b256cc#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a8a510e#egg=aas-core-codegen"
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@44756fb#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@607f65c#egg=aas-core-codegen"
     ],
     py_modules=["test_codegen"],
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -728,15 +728,14 @@ export class AdministrativeInformation extends Class implements IHasDataSpecific
  * The value of a qualifiable element may be further qualified by one or more
  * qualifiers.
  *
- * @remarks
- * **Note**:
- * This constraint is checked at {@link Submodel}.
- *
  * Constraint `AASd-119`:
  * If any {@link Qualifier.kind} value of {@link qualifiers} is
  * equal to {@link QualifierKind.TemplateQualifier} and the qualified element
  * inherits from {@link IHasKind} then the qualified element shall be of
  * kind Template ({@link IHasKind.kind} = {@link ModellingKind.Template}).
+ *
+ * **Note**:
+ * This constraint is checked at {@link Submodel}.
  */
 export interface IQualifiable extends Class {
   /**
@@ -1356,9 +1355,14 @@ export class AssetAdministrationShell
  * does not already exist, the corresponding attribute {@link AssetInformation.globalAssetId} is
  * optional.
  *
+ * Constraint `AASd-116`:
+ * `globalAssetId` is a reserved key. If used as value for
+ * {@link SpecificAssetId.name} then {@link SpecificAssetId.value} shall be
+ * identical to {@link AssetInformation.globalAssetId}.
+ *
  * **Note**:
- * Constraint AASd-116 is important to enable a generic search across global
- * and specific asset IDs.
+ * Constraint AASd-116 is important to enable a generic search across
+ * global and specific asset IDs.
  *
  * **Note**:
  * In the book, Constraint AASd-116 imposes a
@@ -1369,11 +1373,6 @@ export class AssetAdministrationShell
  *
  * We implement the constraint as case-sensitive instead to allow
  * for interoperability across different culture settings.
- *
- * Constraint `AASd-116`:
- * `globalAssetId` is a reserved key. If used as value for
- * {@link SpecificAssetId.name} then {@link SpecificAssetId.value} shall be
- * identical to {@link AssetInformation.globalAssetId}.
  *
  * Constraint `AASd-131`:
  * For {@link AssetInformation} either the {@link AssetInformation.globalAssetId} shall be
@@ -8092,17 +8091,44 @@ export class Capability extends Class implements ISubmodelElement {
  * The description of the concept should follow a standardized schema (realized as
  * data specification template).
  *
- * **Note**:
- * Note: categories are deprecated since V3.0 of Part 1a of the document series
- * "Details of the Asset Administration Shell".
+ * Constraint `AASc-3a-004`:
+ * For a {@link ConceptDescription} with {@link ConceptDescription.category} `PROPERTY` or
+ * `VALUE` using data specification IEC61360,
+ * the {@link DataSpecificationIec61360.dataType} is mandatory and shall be
+ * one of: `DATE`, `STRING`, `STRING_TRANSLATABLE`, `INTEGER_MEASURE`,
+ * `INTEGER_COUNT`, `INTEGER_CURRENCY`, `REAL_MEASURE`, `REAL_COUNT`,
+ * `REAL_CURRENCY`, `BOOLEAN`, `RATIONAL`, `RATIONAL_MEASURE`,
+ * `TIME`, `TIMESTAMP`.
  *
  * **Note**:
  * Note: categories are deprecated since V3.0 of Part 1a of the document series
  * "Details of the Asset Administration Shell".
+ *
+ * Constraint `AASc-3a-005`:
+ * For a {@link ConceptDescription} with {@link ConceptDescription.category} `REFERENCE`
+ * using data specification template IEC61360,
+ * the {@link DataSpecificationIec61360.dataType} shall be
+ * one of: `STRING`, `IRI`, `IRDI`.
+ *
+ * **Note**:
+ * Note: categories are deprecated since V3.0 of Part 1a of the document series
+ * "Details of the Asset Administration Shell".
+ *
+ * Constraint `AASc-3a-006`:
+ * For a {@link ConceptDescription} with {@link ConceptDescription.category} `DOCUMENT`
+ * using data specification IEC61360,
+ * the {@link DataSpecificationIec61360.dataType} shall be one of `FILE`,
+ * `BLOB`, `HTML`
  *
  * **Note**:
  * Categories are deprecated since V3.0 of Part 1a of the document series
  * "Details of the Asset Administration Shell".
+ *
+ * Constraint `AASc-3a-007`:
+ * For a {@link ConceptDescription} with {@link ConceptDescription.category} `QUALIFIER_TYPE`
+ * using data specification IEC61360,
+ * the {@link DataSpecificationIec61360.dataType} is mandatory and shall be
+ * defined.
  *
  * **Note**:
  * Categories are deprecated since V3.0 of Part 1a of the document series
@@ -10236,18 +10262,6 @@ export class LangStringDefinitionTypeIec61360
  *
  * @remarks
  * **Note**:
- * It is also possible that both {@link DataSpecificationIec61360.value} and {@link DataSpecificationIec61360.valueList} are empty.
- * This is the case for concept descriptions that define the semantics of a
- * property but do not have an enumeration ({@link DataSpecificationIec61360.valueList}) as data type.
- *
- * **Note**:
- * Although it is possible to define a {@link ConceptDescription} for a
- * :attr:´value_list`,
- * it is not possible to reuse this {@link DataSpecificationIec61360.valueList}.
- * It is only possible to directly add a {@link DataSpecificationIec61360.valueList} as data type
- * to a specific semantic definition of a property.
- *
- * **Note**:
  * IEC61360 requires also a globally unique identifier for a concept
  * description. This ID is not part of the data specification template.
  * Instead the {@link ConceptDescription.id} as inherited via
@@ -10261,6 +10275,23 @@ export class LangStringDefinitionTypeIec61360
  * {@link ConceptDescription.displayName} and
  * {@link DataSpecificationIec61360.preferredName}. Same holds for
  * {@link ConceptDescription.description} and {@link DataSpecificationIec61360.definition}.
+ *
+ * Constraint `AASc-3a-010`:
+ * If {@link DataSpecificationIec61360.value} is not empty then {@link DataSpecificationIec61360.valueList} shall be empty
+ * and vice versa.
+ *
+ * **Note**:
+ * It is also possible that both {@link DataSpecificationIec61360.value} and {@link DataSpecificationIec61360.valueList} are
+ * empty. This is the case for concept descriptions that define the semantics
+ * of a property but do not have an enumeration ({@link DataSpecificationIec61360.valueList}) as
+ * data type.
+ *
+ * **Note**:
+ * Although it is possible to define a {@link ConceptDescription} for a
+ * :attr:´value_list`,
+ * it is not possible to reuse this {@link DataSpecificationIec61360.valueList}.
+ * It is only possible to directly add a {@link DataSpecificationIec61360.valueList} as data type
+ * to a specific semantic definition of a property.
  *
  * Constraint `AASc-3a-009`:
  * If {@link DataSpecificationIec61360.dataType} one of:

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -2580,7 +2580,8 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
             that.specificAssetIds,
             (specificAssetId) =>
               specificAssetId.name != "globalAssetId" ||
-              (specificAssetId.name == "globalAssetId" &&
+              (that.globalAssetId !== null &&
+                specificAssetId.name == "globalAssetId" &&
                 specificAssetId.value == that.globalAssetId)
           )
         )
@@ -2875,7 +2876,7 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
     if (
       !(
         !(that.submodelElements !== null) ||
-        !(that.kind != AasTypes.ModellingKind.Template) ||
+        !(that.kindOrDefault() != AasTypes.ModellingKind.Template) ||
         AasCommon.every(
           AasCommon.map(
             that.submodelElements,
@@ -7203,7 +7204,7 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
     if (
       !(
         !(
-          that.dataType === null &&
+          that.dataType !== null &&
           AasConstants.IEC_61360_DATA_TYPES_WITH_UNIT.has(that.dataType)
         ) ||
         that.unit !== null ||

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json
@@ -2,17 +2,7 @@
   "assetAdministrationShells": [
     {
       "administration": {
-        "creator": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "creator": "Unexpected string value",
         "embeddedDataSpecifications": [
           {
             "dataSpecification": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AdministrativeInformation/creator.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].administration.creator: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].administration.creator: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json
@@ -56,17 +56,7 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "first": "Unexpected string value",
           "idShort": "PiXO1wyHierj",
           "modelType": "AnnotatedRelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/first.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].first: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].first: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json
@@ -73,17 +73,7 @@
               "valueType": "xs:long"
             }
           ],
-          "second": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "second": "Unexpected string value",
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/second.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].second: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].second: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json
@@ -82,17 +82,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AnnotatedRelationshipElement/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json
@@ -1,17 +1,7 @@
 {
   "assetAdministrationShells": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "assetInformation": {
         "assetKind": "NotApplicable",
         "globalAssetId": "something_eea66fa1"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/administration.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].administration: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].administration: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json
@@ -2,17 +2,7 @@
   "assetAdministrationShells": [
     {
       "administration": {},
-      "assetInformation": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "assetInformation": "Unexpected string value",
       "category": "something_1dc62cea",
       "derivedFrom": {
         "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/assetInformation.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].assetInformation: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json
@@ -7,17 +7,7 @@
         "globalAssetId": "something_eea66fa1"
       },
       "category": "something_1dc62cea",
-      "derivedFrom": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "derivedFrom": "Unexpected string value",
       "description": [
         {
           "language": "Tvwqa-500-8EQd-y-8f5-k-vqdMn7-Ohw9-CcA628-DHKP-hPAjUZ-cnr1REUf-S8-p-9X0r-wtCI-KunG3uzI-7dGUsrTu-fY7-C3-hFN-Y-ML69DgnJ-0-Y0H-TLACBVB-Z0HRibbz-yzSf8dvR-zAn-B-6h8VjcKX-jnwR-0Z8l-ghRIZ7mo-wZG7-zXHdSIV-Oy-8dH00A6L-nJY2dA1-57o8dQ-RpxkBTbE-qBJR-M-DyGDA3U-aguRfIhj-x-XmO-1u",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetAdministrationShell/derivedFrom.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].derivedFrom: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].derivedFrom: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json
@@ -4,17 +4,7 @@
       "assetInformation": {
         "assetKind": "NotApplicable",
         "assetType": "something_9f4c5692",
-        "defaultThumbnail": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "defaultThumbnail": "Unexpected string value",
         "globalAssetId": "something_c71f0c8f"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/AssetInformation/defaultThumbnail.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.defaultThumbnail: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].assetInformation.defaultThumbnail: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json
@@ -54,17 +54,7 @@
           "idShort": "PiXO1wyHierj",
           "lastUpdate": "-3020-08-21T24:00:00.0Z",
           "maxInterval": "PT130S",
-          "messageBroker": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "messageBroker": "Unexpected string value",
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/messageBroker.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].messageBroker: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].messageBroker: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json
@@ -66,17 +66,7 @@
           "messageTopic": "something_99f1a7ac",
           "minInterval": "-P1Y",
           "modelType": "BasicEventElement",
-          "observed": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "observed": "Unexpected string value",
           "qualifiers": [
             {
               "type": "something_500f973e",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/observed.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].observed: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].observed: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json
@@ -81,17 +81,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "state": "off",
           "supplementalSemanticIds": [
             {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/BasicEventElement/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Blob/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Capability/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json
@@ -1,17 +1,7 @@
 {
   "conceptDescriptions": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "category": "something_07a45fb3",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ConceptDescription/administration.json.error
@@ -1,1 +1,1 @@
-conceptDescriptions[0].administration: Expected a JSON object, but got a JSON array
+conceptDescriptions[0].administration: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json
@@ -24,17 +24,7 @@
                 "text": "something_2ae95f9f"
               }
             ],
-            "levelType": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "levelType": "Unexpected string value",
             "modelType": "DataSpecificationIec61360",
             "preferredName": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/levelType.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.levelType: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.levelType: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json
@@ -50,17 +50,7 @@
             "sourceOfDefinition": "something_1bd907c8",
             "symbol": "something_c13116d7",
             "unit": "something_a6bd9450",
-            "unitId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "unitId": "Unexpected string value",
             "value": "something_13759f45",
             "valueFormat": "something_f019e5a8"
           }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/DataSpecificationIec61360/unitId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.unitId: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.unitId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json
@@ -7,17 +7,7 @@
       },
       "embeddedDataSpecifications": [
         {
-          "dataSpecification": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "dataSpecification": "Unexpected string value",
           "dataSpecificationContent": {
             "modelType": "DataSpecificationIec61360",
             "preferredName": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecification.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecification: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecification: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json
@@ -16,17 +16,7 @@
             ],
             "type": "ExternalReference"
           },
-          "dataSpecificationContent": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "dataSpecificationContent": "Unexpected string value"
         }
       ],
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/EmbeddedDataSpecification/dataSpecificationContent.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "statements": [
             {
               "idShort": "something_7cdc9635",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Entity/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json
@@ -19,17 +19,7 @@
               "type": "ModelReference"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Extension/semanticId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0].semanticId: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].extensions[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/File/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json
@@ -84,17 +84,7 @@
               "text": "something_cd7e6587"
             }
           ],
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "valueId": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/MultiLanguageProperty/valueId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].valueId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json
@@ -102,17 +102,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Operation/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json
@@ -8,17 +8,7 @@
           "idShort": "something3fdd3eb4",
           "inputVariables": [
             {
-              "value": [
-                {
-                  "keys": [
-                    {
-                      "type": "GlobalReference",
-                      "value": "unexpected instance"
-                    }
-                  ],
-                  "type": "ExternalReference"
-                }
-              ]
+              "value": "Unexpected string value"
             }
           ],
           "modelType": "Operation"

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/OperationVariable/value.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].inputVariables[0].value: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].inputVariables[0].value: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json
@@ -79,17 +79,7 @@
             }
           ],
           "value": "0061707",
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "valueId": "Unexpected string value",
           "valueType": "xs:decimal"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Property/valueId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].valueId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].valueId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json
@@ -7,17 +7,7 @@
       "qualifiers": [
         {
           "kind": "TemplateQualifier",
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].qualifiers[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json
@@ -29,17 +29,7 @@
           ],
           "type": "something_5964ab43",
           "value": "001",
-          "valueId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "valueId": "Unexpected string value",
           "valueType": "xs:integer"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Qualifier/valueId.json.error
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0].valueId: Expected a JSON object, but got a JSON array
+submodels[0].qualifiers[0].valueId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Range/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json
@@ -12,17 +12,7 @@
             "value": "urn:an-example08:f3f73640"
           }
         ],
-        "referredSemanticId": [
-          {
-            "keys": [
-              {
-                "type": "GlobalReference",
-                "value": "unexpected instance"
-              }
-            ],
-            "type": "ExternalReference"
-          }
-        ],
+        "referredSemanticId": "Unexpected string value",
         "type": "ModelReference"
       },
       "id": "something_142922d6",

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Reference/referredSemanticId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].derivedFrom.referredSemanticId: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].derivedFrom.referredSemanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json
@@ -78,17 +78,7 @@
               "type": "ModelReference"
             }
           ],
-          "value": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ]
+          "value": "Unexpected string value"
         }
       ]
     }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ReferenceElement/value.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].value: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].value: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json
@@ -50,17 +50,7 @@
               "name": "something_aa1af8b3"
             }
           ],
-          "first": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "first": "Unexpected string value",
           "idShort": "PiXO1wyHierj",
           "modelType": "RelationshipElement",
           "qualifiers": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/first.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].first: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].first: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json
@@ -67,17 +67,7 @@
               "valueType": "xs:long"
             }
           ],
-          "second": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "second": "Unexpected string value",
           "semanticId": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/second.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].second: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].second: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json
@@ -76,17 +76,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/RelationshipElement/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json
@@ -5,17 +5,7 @@
         "assetKind": "NotApplicable",
         "specificAssetIds": [
           {
-            "externalSubjectId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "externalSubjectId": "Unexpected string value",
             "name": "something_b0b6ce88",
             "semanticId": {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/externalSubjectId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.specificAssetIds[0].externalSubjectId: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].assetInformation.specificAssetIds[0].externalSubjectId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json
@@ -15,17 +15,7 @@
               "type": "ExternalReference"
             },
             "name": "something_b0b6ce88",
-            "semanticId": [
-              {
-                "keys": [
-                  {
-                    "type": "GlobalReference",
-                    "value": "unexpected instance"
-                  }
-                ],
-                "type": "ExternalReference"
-              }
-            ],
+            "semanticId": "Unexpected string value",
             "supplementalSemanticIds": [
               {
                 "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SpecificAssetId/semanticId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.specificAssetIds[0].semanticId: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].assetInformation.specificAssetIds[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json
@@ -1,17 +1,7 @@
 {
   "submodels": [
     {
-      "administration": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "administration": "Unexpected string value",
       "category": "something_91042c92",
       "description": [
         {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/administration.json.error
@@ -1,1 +1,1 @@
-submodels[0].administration: Expected a JSON object, but got a JSON array
+submodels[0].administration: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json
@@ -57,17 +57,7 @@
           "valueType": "xs:int"
         }
       ],
-      "semanticId": [
-        {
-          "keys": [
-            {
-              "type": "GlobalReference",
-              "value": "unexpected instance"
-            }
-          ],
-          "type": "ExternalReference"
-        }
-      ],
+      "semanticId": "Unexpected string value",
       "submodelElements": [
         {
           "first": {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/Submodel/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json
@@ -58,17 +58,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementCollection/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json
@@ -59,17 +59,7 @@
               "valueType": "xs:long"
             }
           ],
-          "semanticId": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticId": "Unexpected string value",
           "semanticIdListElement": {
             "keys": [
               {

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticId.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticId: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json
@@ -68,17 +68,7 @@
             ],
             "type": "ExternalReference"
           },
-          "semanticIdListElement": [
-            {
-              "keys": [
-                {
-                  "type": "GlobalReference",
-                  "value": "unexpected instance"
-                }
-              ],
-              "type": "ExternalReference"
-            }
-          ],
+          "semanticIdListElement": "Unexpected string value",
           "supplementalSemanticIds": [
             {
               "keys": [

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/SubmodelElementList/semanticIdListElement.json.error
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].semanticIdListElement: Expected a JSON object, but got a JSON array
+submodels[0].submodelElements[0].semanticIdListElement: Expected a JSON object, but got: string

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json
@@ -32,17 +32,7 @@
               "valueReferencePairs": [
                 {
                   "value": "something_63781b6f",
-                  "valueId": [
-                    {
-                      "keys": [
-                        {
-                          "type": "GlobalReference",
-                          "value": "unexpected instance"
-                        }
-                      ],
-                      "type": "ExternalReference"
-                    }
-                  ]
+                  "valueId": "Unexpected string value"
                 }
               ]
             }

--- a/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json.error
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/TypeViolation/ValueReferencePair/valueId.json.error
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs[0].valueId: Expected a JSON object, but got a JSON array
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs[0].valueId: Expected a JSON object, but got: string

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json
@@ -1,15 +1,5 @@
 {
-  "observableReference": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "observableReference": "Unexpected string value",
   "observableSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json.error
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableReference.json.error
@@ -1,1 +1,1 @@
-observableReference: Expected a JSON object, but got a JSON array
+observableReference: Expected a JSON object, but got: string

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json
@@ -8,17 +8,7 @@
     ],
     "type": "ModelReference"
   },
-  "observableSemanticId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "observableSemanticId": "Unexpected string value",
   "payload": "/TsF2AbyQb1dIa0=",
   "source": {
     "keys": [

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json.error
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/observableSemanticId.json.error
@@ -1,1 +1,1 @@
-observableSemanticId: Expected a JSON object, but got a JSON array
+observableSemanticId: Expected a JSON object, but got: string

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json
@@ -18,17 +18,7 @@
     "type": "ModelReference"
   },
   "payload": "/TsF2AbyQb1dIa0=",
-  "source": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "source": "Unexpected string value",
   "sourceSemanticId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json.error
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/source.json.error
@@ -1,1 +1,1 @@
-source: Expected a JSON object, but got a JSON array
+source: Expected a JSON object, but got: string

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json
@@ -31,17 +31,7 @@
     ],
     "type": "ModelReference"
   },
-  "sourceSemanticId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "sourceSemanticId": "Unexpected string value",
   "subjectId": {
     "keys": [
       {

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json.error
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/sourceSemanticId.json.error
@@ -1,1 +1,1 @@
-sourceSemanticId: Expected a JSON object, but got a JSON array
+sourceSemanticId: Expected a JSON object, but got: string

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json
@@ -40,17 +40,7 @@
     ],
     "type": "ModelReference"
   },
-  "subjectId": [
-    {
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "unexpected instance"
-        }
-      ],
-      "type": "ExternalReference"
-    }
-  ],
+  "subjectId": "Unexpected string value",
   "timeStamp": "2022-04-01T24:00:00-00:00",
   "topic": "something_8f13d2dd"
 }

--- a/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json.error
+++ b/test_data/Json/SelfContained/Unexpected/TypeViolation/EventPayload/subjectId.json.error
@@ -1,1 +1,1 @@
-subjectId: Expected a JSON object, but got a JSON array
+subjectId: Expected a JSON object, but got: string


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 44756fb],
* [aas-core-codegen 607f65c] and
* [aas-core3.0-testgen bf3720d7].

This is an important patch propagating in particular the following fixes which affected the constraints and their documentation:

* Pull requests in aas-core-meta [#271], [#272] and [#273] which affect the nullability checks in constraints,
* Pull request in aas-core-meta [#275] which affects the documentation of many constraints.

This patch also includes a propagation of improved test data:

* Pull request in aas-core3.0-testgen [#13] which makes the type violations of enumerations more explicit and thus easier to debug.

[aas-core-meta 44756fb]: https://github.com/aas-core-works/aas-core-meta/commit/44756fb
[aas-core-codegen 607f65c]: https://github.com/aas-core-works/aas-core-codegen/commit/607f65c
[aas-core3.0-testgen bf3720d7]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/bf3720d7

[#271]: https://github.com/aas-core-works/aas-core-meta/pull/271
[#272]: https://github.com/aas-core-works/aas-core-meta/pull/272
[#273]: https://github.com/aas-core-works/aas-core-meta/pull/273
[#275]: https://github.com/aas-core-works/aas-core-meta/pull/275

[#13]: https://github.com/aas-core-works/aas-core3.0-testgen/pull/13