### PR TITLE
Release 1.0.0-rc.2

### DIFF
--- a/.idea/aas-core3.0-typescript.iml
+++ b/.idea/aas-core3.0-typescript.iml
@@ -2,6 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/dev_scripts" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.8 (aas-core3.0-typescript)" jdkType="Python SDK" />

--- a/README.md
+++ b/README.md
@@ -944,6 +944,19 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 
 ## Changelog
 
+### 1.0.0-rc.2
+
+* Update to aas-core-meta, codegen, testgen 44756fb, 607f65c,
+  bf3720d7 (#7)
+
+  This is an important patch propagating in particular the following fixes
+  which affected the constraints and their documentation:
+
+    * Pull requests in aas-core-meta 271, 272 and 273 which affect the
+      nullability checks in constraints,
+    * Pull request in aas-core-meta 275 which affects the documentation
+      of many constraints.
+
 ### 1.0.0-rc.1
 
 * Initial version, ready for the first reviews

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aas-core-works/aas-core3.0-typescript",
   "private": false,
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aas-core-works/aas-core3.0-typescript"


### PR DESCRIPTION
* Update to aas-core-meta, codegen, testgen 44756fb, 607f65c, bf3720d7 (#7)

  This is an important patch propagating in particular the following fixes which affected the constraints and their documentation:

    * Pull requests in aas-core-meta 271, 272 and 273 which affect the nullability checks in constraints,

    * Pull request in aas-core-meta 275 which affects the documentation of many constraints.