### PR TITLE
Update to aas-core-meta, codegen, testgen 4d7e59e, 7e264a0, 9b43de2e

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: 607f65c
+The revision of aas-core-codegen was: 7e264a0
 """

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -130,6 +130,9 @@ class Error:
         self.cause = cause
         self.path = Path()
 
+    def __repr__(self) -> str:
+        return f"Error(path={self.path}, cause={self.cause})"
+
 
 # noinspection SpellCheckingInspection
 def _construct_matches_id_short() -> Pattern[str]:
@@ -2461,15 +2464,12 @@ class _Transformer(
                 (
                 (
                     (that.global_asset_id is not None)
-                    and (that.specific_asset_ids is None)
+                    or (that.specific_asset_ids is not None)
                 )
             )
-                or (
-                    (
-                        (that.global_asset_id is None)
-                        and (that.specific_asset_ids is not None)
-                        and len(that.specific_asset_ids) >= 1
-                    )
+                and (
+                    not (that.specific_asset_ids is not None)
+                    or (len(that.specific_asset_ids) >= 1)
                 )
             )
         ):
@@ -8062,21 +8062,10 @@ class _Transformer(
             that: aas_types.DataSpecificationIEC61360
     ) -> Iterator[Error]:
         if not (
-            (
-                (
-                (
-                    (that.value is not None)
-                    and (that.value_list is None)
-                )
-            )
-                or (
-                    (
-                        (that.value is None)
-                        and (that.value_list is not None)
-                        and len(that.value_list.value_reference_pairs) >= 1
-                    )
-                )
-            )
+            not ((
+                (that.value is not None)
+                and (that.value_list is not None)
+            ))
         ):
             yield Error(
                 'Constraint AASc-3a-010: If value is not empty then value ' +

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -30,8 +30,8 @@ setup(
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
         "icontract>=2.6.1,<3",
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@44756fb#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@607f65c#egg=aas-core-codegen"
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@4d7e59e#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@7e264a0#egg=aas-core-codegen"
     ],
     py_modules=["test_codegen"],
 )

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -24,6 +24,11 @@ import * as AasCommon from "./common";
 import * as AasConstants from "./constants";
 import * as AasTypes from "./types";
 
+// The generated code might contain deliberately double negations. For example,
+// when the constraint is formulated as a NAND and we check that the constraint
+// is not fulfilled. Therefore, we disable this linting rule.
+/* eslint no-extra-boolean-cast: 0 */
+
 /**
  * Represent a property access on a path to an erroneous value.
  */
@@ -2597,10 +2602,8 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
 
     if (
       !(
-        (that.globalAssetId !== null && that.specificAssetIds === null) ||
-        (that.globalAssetId === null &&
-          that.specificAssetIds !== null &&
-          that.specificAssetIds.length >= 1)
+        (that.globalAssetId !== null || that.specificAssetIds !== null) &&
+        (!(that.specificAssetIds !== null) || that.specificAssetIds.length >= 1)
       )
     ) {
       yield new VerificationError(
@@ -7187,14 +7190,7 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
     that: AasTypes.DataSpecificationIec61360,
     context: boolean
   ): IterableIterator<VerificationError> {
-    if (
-      !(
-        (that.value !== null && that.valueList === null) ||
-        (that.value === null &&
-          that.valueList !== null &&
-          that.valueList.valueReferencePairs.length >= 1)
-      )
-    ) {
+    if (!!(that.value !== null && that.valueList !== null)) {
       yield new VerificationError(
         "Constraint AASc-3a-010: If value is not empty then value " +
           "list shall be empty and vice versa."

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
@@ -1,2 +1,1 @@
-.assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Constraint AASc-3a-010: If value is not empty then value list shall be empty and vice versa.
 .assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList: Value reference pair types must contain at least one item.


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 4d7e59e],
* [aas-core-codegen 7e264a0] and
* [aas-core3.0-testgen 9b43de2e].

Notably, this includes two important fixes from aas-core-meta:

* [V3 Fix AASc-3a-010-for-NAND (#281)], and
* [V3 Fix inclusive OR in AASd-131 (#280)].

Related to #12 and #9.

[aas-core-meta 4d7e59e]: https://github.com/aas-core-works/aas-core-meta/commit/4d7e59e
[aas-core-codegen 7e264a0]: https://github.com/aas-core-works/aas-core-codegen/commit/7e264a0
[aas-core3.0-testgen 9b43de2e]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9b43de2e
[V3 Fix AASc-3a-010-for-NAND (#281)]: https://github.com/aas-core-works/aas-core-meta/pull/281
[V3 Fix inclusive OR in AASd-131 (#280)]: https://github.com/aas-core-works/aas-core-meta/pull/280