### PR TITLE
Update to aas-core-meta, codegen, testgen 79314c6, 94399e1, e1087880

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: 256cc8a
+The revision of aas-core-codegen was: 94399e1
 """

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -524,7 +524,7 @@ def _construct_matches_xs_date() -> Pattern[str]:
     month_frag = '((0[1-9])|(1[0-2]))'
     day_frag = f'((0[1-9])|([12]{digit})|(3[01]))'
     minute_frag = f'[0-5]{digit}'
-    timezone_frag = f'(Z|(\\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)'
+    timezone_frag = f'(Z|(\\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))'
     date_lexical_rep = f'{year_frag}-{month_frag}-{day_frag}{timezone_frag}?'
     pattern = f'^{date_lexical_rep}$'
 
@@ -557,7 +557,7 @@ def _construct_matches_xs_date_time() -> Pattern[str]:
     minute_frag = f'[0-5]{digit}'
     second_frag = f'([0-5]{digit})(\\.{digit}+)?'
     end_of_day_frag = '24:00:00(\\.0+)?'
-    timezone_frag = f'(Z|(\\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)'
+    timezone_frag = f'(Z|(\\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))'
     date_time_lexical_rep = f'{year_frag}-{month_frag}-{day_frag}T(({hour_frag}:{minute_frag}:{second_frag})|{end_of_day_frag}){timezone_frag}?'
     pattern = f'^{date_time_lexical_rep}$'
 

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -30,8 +30,8 @@ setup(
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
         "icontract>=2.6.1,<3",
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@c9692bc#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@256cc8a#egg=aas-core-codegen"
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@79314c6#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@94399e1#egg=aas-core-codegen"
     ],
     py_modules=["test_codegen"],
 )

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -535,7 +535,7 @@ function constructMatchesXsDate(): RegExp {
   const monthFrag = "((0[1-9])|(1[0-2]))";
   const dayFrag = `((0[1-9])|([12]${digit})|(3[01]))`;
   const minuteFrag = `[0-5]${digit}`;
-  const timezoneFrag = `(Z|(\\+|-)(0${digit}|1[0-3]):${minuteFrag}|14:00)`;
+  const timezoneFrag = `(Z|(\\+|-)((0${digit}|1[0-3]):${minuteFrag}|14:00))`;
   const dateLexicalRep = `${yearFrag}-${monthFrag}-${dayFrag}${timezoneFrag}?`;
   const pattern = `^${dateLexicalRep}$`;
 
@@ -568,7 +568,7 @@ function constructMatchesXsDateTime(): RegExp {
   const minuteFrag = `[0-5]${digit}`;
   const secondFrag = `([0-5]${digit})(\\.${digit}+)?`;
   const endOfDayFrag = "24:00:00(\\.0+)?";
-  const timezoneFrag = `(Z|(\\+|-)(0${digit}|1[0-3]):${minuteFrag}|14:00)`;
+  const timezoneFrag = `(Z|(\\+|-)((0${digit}|1[0-3]):${minuteFrag}|14:00))`;
   const dateTimeLexicalRep = `${yearFrag}-${monthFrag}-${dayFrag}T((${hourFrag}:${minuteFrag}:${secondFrag})|${endOfDayFrag})${timezoneFrag}?`;
   const pattern = `^${dateTimeLexicalRep}$`;
 

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/fuzzed_01.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "0705-04-1014:00",
+          "value": "0705-04-10+14:00",
           "valueType": "xs:date"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/fuzzed_05.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "0532-09-07T18:47:5214:00",
+          "value": "0532-09-07T18:47:52+14:00",
           "valueType": "xs:dateTime"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_06.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/fuzzed_01.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "0705-04-1014:00",
+          "value": "0705-04-10+14:00",
           "valueType": "xs:date"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/fuzzed_05.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "0532-09-07T18:47:5214:00",
+          "value": "0532-09-07T18:47:52+14:00",
           "valueType": "xs:dateTime"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_06.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/fuzzed_01.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "0705-04-1014:00",
+          "value": "0705-04-10+14:00",
           "valueType": "xs:date"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/fuzzed_05.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "0532-09-07T18:47:5214:00",
+          "value": "0532-09-07T18:47:52+14:00",
           "valueType": "xs:dateTime"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_06.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/fuzzed_01.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "0705-04-1014:00",
-          "min": "0705-04-1014:00",
+          "max": "0705-04-10+14:00",
+          "min": "0705-04-10+14:00",
           "modelType": "Range",
           "valueType": "xs:date"
         }

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/fuzzed_05.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "0532-09-07T18:47:5214:00",
-          "min": "0532-09-07T18:47:5214:00",
+          "max": "0532-09-07T18:47:52+14:00",
+          "min": "0532-09-07T18:47:52+14:00",
           "modelType": "Range",
           "valueType": "xs:dateTime"
         }

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_06.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "+7626E-86876716",
-          "min": "+7626E-86876716",
+          "max": "+76E-86",
+          "min": "+76E-86",
           "modelType": "Range",
           "valueType": "xs:double"
         }

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "-.66E-452289",
-          "min": "-.66E-452289",
+          "max": "-.66E-45",
+          "min": "-.66E-45",
           "modelType": "Range",
           "valueType": "xs:double"
         }


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 79314c6],
* [aas-core-codegen 94399e1] and
* [aas-core3.0-testgen e1087880].

Notably, we fix the patterns for date and date-times with zone offset `14:00` which previously allowed for a concatenation without a plus sign.

In addition, we fix the test data for defects which were detected while testing with the generated C++ SDK. This concerns the examples of doubles which overflowed in C++, but where silently accepted otherwise.

[aas-core-meta 79314c6]: https://github.com/aas-core-works/aas-core-meta/commit/79314c6
[aas-core-codegen 94399e1]: https://github.com/aas-core-works/aas-core-codegen/commit/94399e1
[aas-core3.0-testgen e1087880]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/e1087880