### PR TITLE
Release 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,6 +944,12 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 
 ## Changelog
 
+### 1.0.1 (2024-03-13)
+
+This patch release brings about the fix for patterns concerning dates and
+date-times with zone offset `14:00` which previously allowed for
+a concatenation without a plus sign.
+
 ### 1.0.0 (2024-02-02)
 
 This is the first stable release. The release candidates stood

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aas-core-works/aas-core3.0-typescript",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aas-core-works/aas-core3.0-typescript"


### PR DESCRIPTION
This patch release brings about the fix for patterns concerning dates and date-times with zone offset `14:00` which previously allowed for a concatenation without a plus sign.