### PR TITLE
Release 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,6 +944,12 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 
 ## Changelog
 
+### 1.0.2 (2024-03-23)
+
+In this patch version, we propagate the fix from abnf-to-regex related
+to maximum qualifiers which had been mistakenly represented as exact
+repetition before.
+
 ### 1.0.1 (2024-03-13)
 
 This patch release brings about the fix for patterns concerning dates and

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aas-core-works/aas-core3.0-typescript",
   "private": false,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aas-core-works/aas-core3.0-typescript"


### PR DESCRIPTION
In this patch version, we propagate the fix from abnf-to-regex related to maximum qualifiers which had been mistakenly represented as exact repetition before.