### PR TITLE
Release 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,6 +944,11 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 
 ## Changelog
 
+### 1.0.3 (2024-04-16)
+
+The `dataSpecification` field in `EmbeddedDataSpecification` is made
+optional, according to the book.
+
 ### 1.0.2 (2024-03-23)
 
 In this patch version, we propagate the fix from abnf-to-regex related

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aas-core-works/aas-core3.0-typescript",
   "private": false,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aas-core-works/aas-core3.0-typescript"


### PR DESCRIPTION
The `dataSpecification` field in `EmbeddedDataSpecification` is made optional, according to the book.