### PR TITLE
Replace test data first in the update script

### DIFF
--- a/.idea/aas-core3.0-typescript.iml
+++ b/.idea/aas-core3.0-typescript.iml
@@ -5,7 +5,7 @@
       <sourceFolder url="file://$MODULE_DIR$/dev_scripts" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (aas-core3.0-typescript)" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
+++ b/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
@@ -290,13 +290,13 @@ def _replace_test_data(
 
     print(f"Removing the test data from: {test_data_dir}")
 
-    for pth in [
-        test_data_dir / name
-        for name in ("descend", "descendOnce", "Json", "xOrDefault")
-    ]:
-        if pth.exists():
-            print(f"Removing {pth} ...")
-            shutil.rmtree(pth)
+    for pth in sorted(
+        sub_pth
+        for sub_pth in test_data_dir.iterdir()
+        if sub_pth.is_dir()
+    ):
+        print(f"Removing {pth} ...")
+        shutil.rmtree(pth)
 
     print(f"Copying the test data from: {aas_core_testgen_repo} ...")
 
@@ -604,11 +604,11 @@ def main() -> int:
         aas_core_codegen_revision=aas_core_codegen_revision,
     )
 
+    _replace_test_data(our_repo=our_repo, aas_core_testgen_repo=aas_core_testgen_repo)
+
     exit_code = _generate_test_code(our_repo=our_repo)
     if exit_code is not None:
         return exit_code
-
-    _replace_test_data(our_repo=our_repo, aas_core_testgen_repo=aas_core_testgen_repo)
 
     _reformat_code(our_repo=our_repo)
 


### PR DESCRIPTION
We need to remove *all* the test data as the specification can introduce breaking changes.

We also need to replace the test data first on breaking changes in specification since the test code generation already runs a couple of preliminary consistency checks against the test data.