### PR TITLE
Update to aas-core-meta, codegen, testgen f9cbdb3, b14237b2, 5a705a0b1

### DIFF
--- a/dev_scripts/aas_core3/__init__.py
+++ b/dev_scripts/aas_core3/__init__.py
@@ -3,5 +3,5 @@ Provide Python SDK as copied from aas-core-codegen test data.
 
 This copy is necessary so that we can decouple from ``aas-core*-python`` repository.
 
-The revision of aas-core-codegen was: 0f7345e1
+The revision of aas-core-codegen was: b14237b2
 """

--- a/dev_scripts/aas_core3/verification.py
+++ b/dev_scripts/aas_core3/verification.py
@@ -3426,21 +3426,21 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.value is not None)
-                    and (
-                        (
-                            that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
-                            or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
-                        )
-                    )
+                    that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
+                    or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
                 )
             )
             or (
                 (
                     (that.value_type_list_element is not None)
-                    and properties_or_ranges_have_value_type(
-                        that.value,
-                        that.value_type_list_element
+                    and (
+                        (
+                            (that.value is None)
+                            or properties_or_ranges_have_value_type(
+                                that.value,
+                                that.value_type_list_element
+                            )
+                        )
                     )
                 )
             )

--- a/dev_scripts/setup.py
+++ b/dev_scripts/setup.py
@@ -30,8 +30,8 @@ setup(
     packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=[
         "icontract>=2.6.1,<3",
-        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@31d6afd#egg=aas-core-meta",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@0f7345e1#egg=aas-core-codegen"
+        "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f9cbdb3#egg=aas-core-meta",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@b14237b2#egg=aas-core-codegen"
     ],
     py_modules=["test_codegen"],
 )

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -3409,12 +3409,12 @@ class Verifier extends AasTypes.AbstractTransformerWithContext<
     if (
       !(
         !(
-          that.value !== null &&
-          (that.typeValueListElement == AasTypes.AasSubmodelElements.Property ||
-            that.typeValueListElement == AasTypes.AasSubmodelElements.Range)
+          that.typeValueListElement == AasTypes.AasSubmodelElements.Property ||
+          that.typeValueListElement == AasTypes.AasSubmodelElements.Range
         ) ||
         (that.valueTypeListElement !== null &&
-          propertiesOrRangesHaveValueType(that.value, that.valueTypeListElement))
+          (that.value === null ||
+            propertiesOrRangesHaveValueType(that.value, that.valueTypeListElement)))
       )
     ) {
       yield new VerificationError(


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta f9cbdb3],
* [aas-core-codegen b14237b2] and
* [aas-core3.0-testgen 5a705a0b1].

Notably, we propagate the fix for AASd-109 where we change the invariant such that it checks for the consistency among properties even when a ``value`` property is missing.

[aas-core-meta f9cbdb3]: https://github.com/aas-core-works/aas-core-meta/commit/f9cbdb3
[aas-core-codegen b14237b2]: https://github.com/aas-core-works/aas-core-codegen/commit/b14237b2
[aas-core3.0-testgen 5a705a0b1]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/5a705a0b1