### PR TITLE
Update to aas-core-meta, codegen, testgen 11b116c5, 9db4f51, 7ddd731

### DIFF
--- a/dev_scripts/codegen/snippets/Verification/ID_shorts_are_unique.ts
+++ b/dev_scripts/codegen/snippets/Verification/ID_shorts_are_unique.ts
@@ -10,11 +10,13 @@ export function idShortsAreUnique(
 ): boolean {
   const idShortSet = new Set<string>();
   for (const referable of referables) {
-    if (idShortSet.has(referable.idShort)) {
-      return false;
-    }
+    if (referable.idShort !== null) {
+      if (idShortSet.has(referable.idShort)) {
+        return false;
+      }
 
-    idShortSet.add(referable.idShort);
+      idShortSet.add(referable.idShort);
+    }
   }
 
   return true;

--- a/dev_scripts/pyproject.toml
+++ b/dev_scripts/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@754e1676",
+    "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9db4f51",
     "requests>=2.32.5",
 ]
 


### PR DESCRIPTION
We update the development requirements to and re-generate everything
with:
* [aas-core-meta 11b116c5],
* [aas-core-codegen 9db4f51] and
* [aas-core3.0-testgen 7ddd731].

There have been a number of fixes in for the 3.0 schema description,
noteably:
* Missing Path_type Constraints ([388])
* Incomplete IdShort docstrings ([385])
* Redundant verification function for RFC8089 path ([382])

Furthermore, this fixes an error in the TypeScript SDK where the
IdShort uniqueness constraint would errornuously fail on unset
IdShorts.

[382]: https://github.com/aas-core-works/aas-core-meta/pull/382
[385]: https://github.com/aas-core-works/aas-core-meta/pull/385
[388]: https://github.com/aas-core-works/aas-core-meta/pull/388
[aas-core-meta 11b116c5]: https://github.com/aas-core-works/aas-core-meta/commit/11b116c5
[aas-core-codegen 9db4f51]: https://github.com/aas-core-works/aas-core-codegen/commit/9db4f51
[aas-core3.0-testgen 7ddd731]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/7ddd731.